### PR TITLE
allow for higher versions of core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = [ "arches<8.2.0,>=8.1.0a8",]
+dependencies = [ "arches<9.0.0",]
 dynamic = []
 
 [tool.setuptools]


### PR DESCRIPTION
currently restriction disallows 8.2 alphas